### PR TITLE
Update links to oauth2.py docs.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -10,8 +10,8 @@ h2. Installation/setup
 ** "SASL":http://cyrusimap.web.cmu.edu/ (libsasl2-dev on Ubuntu)
 ** "libOAuth":http://liboauth.sourceforge.net/ (liboauth-dev on Ubuntu)
 * Build and install the plugin via @make && sudo make install@
-* Go to "Quick Run-Through with xoauth.py":https://code.google.com/p/google-mail-xoauth-tools/wiki/XoauthDotPyRunThrough#Quick_Run-Through_with_xoauth.py and download @xoauth.py@ per their instructions.
-* Follow the step "Create and Authorize an OAuth Token":https://code.google.com/p/google-mail-xoauth-tools/wiki/XoauthDotPyRunThrough#Creating_and_Authorizing_an_OAuth_Token
+* Go to "Quick Run-Through with oauth2.py":https://github.com/google/gmail-oauth2-tools/wiki/OAuth2DotPyRunThrough#quick-run-through-with-oauth2py and download @oauth2.py@ per their instructions.
+* Follow the step "Create and Authorize an OAuth Token":https://github.com/google/gmail-oauth2-tools/wiki/OAuth2DotPyRunThrough#creating-and-authorizing-an-oauth-token
 * Use the @oauth_token@ and @oauth_token_secret@ and add them into the config file @~/.xoauthrc@:
 
 bc. # The last oauth_token output of xoauth.py


### PR DESCRIPTION
code.google.com links are, unfortunately, broken.

For reference: old documentation is archived at http://web.archive.org/web/20140704142433/http://code.google.com/p/google-mail-xoauth-tools/wiki/XoauthDotPyRunThrough.
